### PR TITLE
In-call volume and microphone fixes/tweaks

### DIFF
--- a/prebuilt/system/etc/mixer_paths.xml
+++ b/prebuilt/system/etc/mixer_paths.xml
@@ -1515,7 +1515,7 @@
 
     <path name="handset-mic">
         <path name="main-mic" />
-        <ctl name="ADC1 Volume" value="3" />
+        <ctl name="ADC1 Volume" value="13" />
     </path>
 
     <path name="voice-handset-mic">

--- a/prebuilt/system/etc/mixer_paths.xml
+++ b/prebuilt/system/etc/mixer_paths.xml
@@ -1614,7 +1614,7 @@
         <ctl name="RDAC3 MUX" value="DEM2" />
         <ctl name="DAC1 Switch" value="1" />
         <ctl name="EAR PA Gain" value="POS_6_DB" />
-        <ctl name="RX1 Digital Volume" value="84" />
+        <ctl name="RX1 Digital Volume" value="75" />
     </path>
 
 
@@ -1644,10 +1644,10 @@
         <ctl name="RX2 MIX1 INP1" value="RX2" />
         <ctl name="CLASS_H_DSM MUX" value="DSM_HPHL_RX1" />
         <ctl name="HPHL DAC Switch" value="1" />
-        <ctl name="HPHL Volume" value="20" />
-        <ctl name="HPHR Volume" value="20" />
-        <ctl name="RX1 Digital Volume" value="84" />
-        <ctl name="RX2 Digital Volume" value="84" />
+        <ctl name="HPHL Volume" value="19" />
+        <ctl name="HPHR Volume" value="19" />
+        <ctl name="RX1 Digital Volume" value="75" />
+        <ctl name="RX2 Digital Volume" value="75" />
     </path>
 
     <path name="voice-headset-mic">


### PR DESCRIPTION
Default volume for the ear speaker is tad too loud, you can't reduce it further using buttons on the side. It eventually can damage your hearing (just what happened to me...).

Another fix is for the micrphone when using headphones without additional microphone. Previously when headphones were plugged, ADC1 Volume connected to main-mici was reduced to value of 3. It should be at least the same as value when using the speakerphone.

Additional fine-tuning might be needed.

PS: this mixer_paths.xml file is a mess...
To see how manipulating volumes changes audio waveforms, please see this [link](https://docs.google.com/document/d/1NqfEpbhXfXyqRPJoLxtifbEMNCEuVOIokwT5kyjJ2KI/pub)
